### PR TITLE
Don't call handlers if component destroyed

### DIFF
--- a/addon/components/outside-click/component.js
+++ b/addon/components/outside-click/component.js
@@ -37,11 +37,17 @@ export default Ember.Component.extend(PropTypeMixin, {
   isOutside: false,
 
   handleDown(e) {
+    if (this.isDestroyed || this.isDestroying) {
+      return;
+    }
     const el = this.$()[0];
     if (!el.contains(e.target)) this.set('isOutside', true)
   },
 
   handleUp(e) {
+    if (this.isDestroyed || this.isDestroying) {
+      return;
+    }
     if (this.get('isOutside')) this.get('onOutsideClick')(e)
     this.set('isOutside', false)
   }


### PR DESCRIPTION
This solves the issue if the `{{outside-click}}` component is inside an `{{#if ..}}` block.

The use case I encountered this in was when using inside an `{{ember-tether}}` block.
